### PR TITLE
Add `update-body`, `force-update`, `include-title` and `link-prefix` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,16 +55,18 @@ A full example with all available options and example values is provided below.
 ```
 
 | Key               | Description                                                                                                                                                             | Required | Default |
-| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------- |
-| `github-token`    | Token used to update PR description. `GITHUB_TOKEN` is already available [when you use GitHub actions][ghtoken], so all that is required is to pass it as a param here. | x        | `null`  |
-| `jira-token`      | Token used to fetch Jira Issue information. Check [below](#jira-token) for more details on how to generate the token.                                                   | x        | `null`  |
-| `jira-user`       | The email address of the user that generated the `jira-token`.                                                                                                          | x        | `null`  |
-| `jira-base-url`   | The subdomain of JIRA cloud that you use to access it. Ex: `https://your-domain.atlassian.net`.                                                                         | x        | `null`  |
-| `comment-header`  | A markdown formatted message which will get added to top of the comments the bot makes.                                                                                 |          | `''`    |
-| `comment-trailer` | A markdown formatted message which will get added to bottom of the comments the bot makes.                                                                              |          | `''`    |
-| `fail-on-error`   | A `Boolean` which, if set to `true`, fails the GitHub Action when an error occurs.                                                                                      |          | `false` |
-| `force-update`    | A `Boolean` which, if set to `true`, allows the update to be made after the issue has already been opened which may result in creating multiple comments.               |          | `false` |
-| `update-body`     | A `Boolean` which, if set to `true`, prepends the comment to the body instead of adding a comment to the issue.                                                         |          | `false` |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | -------------- |
+| `github-token`    | Token used to update PR description. `GITHUB_TOKEN` is already available [when you use GitHub actions][ghtoken], so all that is required is to pass it as a param here. | x        | `null`         |
+| `jira-token`      | Token used to fetch Jira Issue information. Check [below](#jira-token) for more details on how to generate the token.                                                   | x        | `null`         |
+| `jira-user`       | The email address of the user that generated the `jira-token`.                                                                                                          | x        | `null`         |
+| `jira-base-url`   | The subdomain of JIRA cloud that you use to access it. Ex: `https://your-domain.atlassian.net`.                                                                         | x        | `null`         |
+| `comment-header`  | A markdown formatted message which will get added to top of the comments the bot makes.                                                                                 |          | `''`           |
+| `comment-trailer` | A markdown formatted message which will get added to bottom of the comments the bot makes.                                                                              |          | `''`           |
+| `fail-on-error`   | A `Boolean` which, if set to `true`, fails the GitHub Action when an error occurs.                                                                                      |          | `false`        |
+| `force-update`    | A `Boolean` which, if set to `true`, allows the update to be made after the issue has already been opened which may result in creating multiple comments.               |          | `false`        |
+| `update-body`     | A `Boolean` which, if set to `true`, prepends the comment to the body instead of adding a comment to the issue.                                                         |          | `false`        |
+| `include-title`   | A `Boolean` which, if set to `true`, adds the jira ticket title to the generated link.                                                                                  |          | `false`        |
+| `link-prefix`     | Text which is added before the jira ticket link.                                                                                                                        |          | `JIRA Issue: ` |
 
 **Special note on `jira-token`:** Since tokens are private, we suggest adding
 them as [GitHub secrets][secrets].

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ on: [pull_request]
 
 jobs:
   action-jira-linter:
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       - uses: exogee-technology/action-jira-linker@v1.0.0

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ A full example with all available options and example values is provided below.
 | `comment-header`  | A markdown formatted message which will get added to top of the comments the bot makes.                                                                                 |          | `''`    |
 | `comment-trailer` | A markdown formatted message which will get added to bottom of the comments the bot makes.                                                                              |          | `''`    |
 | `fail-on-error`   | A `Boolean` which, if set to `true`, fails the GitHub Action when an error occurs.                                                                                      |          | `false` |
+| `force-update`    | A `Boolean` which, if set to `true`, allows the update to be made after the issue has already been opened which may result in creating multiple comments.               |          | `false` |
 
 **Special note on `jira-token`:** Since tokens are private, we suggest adding
 them as [GitHub secrets][secrets].

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ A full example with all available options and example values is provided below.
 | `comment-trailer` | A markdown formatted message which will get added to bottom of the comments the bot makes.                                                                              |          | `''`    |
 | `fail-on-error`   | A `Boolean` which, if set to `true`, fails the GitHub Action when an error occurs.                                                                                      |          | `false` |
 | `force-update`    | A `Boolean` which, if set to `true`, allows the update to be made after the issue has already been opened which may result in creating multiple comments.               |          | `false` |
+| `update-body`     | A `Boolean` which, if set to `true`, prepends the comment to the body instead of adding a comment to the issue.                                                         |          | `false` |
 
 **Special note on `jira-token`:** Since tokens are private, we suggest adding
 them as [GitHub secrets][secrets].

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,14 @@ inputs:
     description: 'Update the issue body with the comment instead of adding a comment'
     required: false
     default: false
+  include-title:
+    description: 'Add jira ticket summary to generated link'
+    required: false
+    default: false
+  link-prefix:
+    description: 'Text which is added before the jira ticket link'
+    required: false
+    default: 'JIRA Issue: '
 
 runs:
   using: 'node20'

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: 'Set this to true if you want action-jira-linker to fail the PR if it cannot find a JIRA issue. Default is false.'
     required: false
     default: false
+  force-update:
+    description: 'Set this to true if you want action-jira-linker to add the comment for PRs that have not been recently opened at the risk of creating duplicate comments, this can be useful while testing the action integration.'
+    required: false
+    default: false
 
 runs:
   using: 'node20'

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,10 @@ inputs:
     description: 'Set this to true if you want action-jira-linker to add the comment for PRs that have not been recently opened at the risk of creating duplicate comments, this can be useful while testing the action integration.'
     required: false
     default: false
+  update-body:
+    description: 'Update the issue body with the comment instead of adding a comment'
+    required: false
+    default: false
 
 runs:
   using: 'node20'

--- a/lib/index.js
+++ b/lib/index.js
@@ -40393,6 +40393,7 @@ var run = async () => {
       required: false
     });
     const failOnError = core2.getInput("fail-on-error", { required: false }) !== "false";
+    const forceUpdate = core2.getInput("force-update", { required: false }) === "true";
     const exit = (message) => {
       let exitCode = 0;
       if (failOnError) {
@@ -40413,7 +40414,7 @@ var run = async () => {
       console.log(`Missing 'pull_request' from github action context. Skipping.`);
       return;
     }
-    if (action !== "opened") {
+    if (!forceUpdate && action !== "opened") {
       console.log("Skipping action to ensure we only comment once.");
       return;
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -37078,6 +37078,8 @@ var Octokit2 = Octokit.plugin(requestLog, import_plugin_rest_endpoint_methods.le
 );
 
 // src/github.ts
+var BODY_HEADER = "<!-- jira link -->\r\n";
+var BODY_FOOTER = "\r\n<!-- end jira link -->";
 var GitHub = class {
   constructor(token) {
     this.addComment = async (comment) => {
@@ -37096,18 +37098,21 @@ var GitHub = class {
     };
     this.updateBody = async (comment) => {
       try {
-        const { owner, repo, issue: issue_number, body } = comment;
+        const { owner, repo, issue: issue_number, linkBody } = comment;
         const issue = await this.client.issues.get({ owner, repo, issue_number });
-        if (!issue.data.body) {
+        let issueBody = issue.data.body;
+        const body = `${BODY_HEADER}${linkBody}${BODY_FOOTER}`;
+        if (!issueBody) {
           await this.client.issues.update({ owner, repo, issue_number, body });
-        } else if (!issue.data.body.includes(body)) {
+        } else {
+          issueBody = issueBody.replace(new RegExp(`${BODY_HEADER}.*${BODY_FOOTER}`, "s"), "");
           await this.client.issues.update({
             owner,
             repo,
             issue_number,
             body: `${body}
 
-${issue.data.body}`
+${issueBody}`
           });
         }
       } catch (error) {
@@ -40416,6 +40421,11 @@ var run = async () => {
     const failOnError = core2.getInput("fail-on-error", { required: false }) !== "false";
     const forceUpdate = core2.getInput("force-update", { required: false }) === "true";
     const updateBody = core2.getInput("update-body", { required: false }) === "true";
+    const includeTitle = core2.getInput("include-title", { required: false }) === "true";
+    const linkPrefix = core2.getInput("link-prefix", {
+      required: false,
+      trimWhitespace: false
+    });
     const exit = (message) => {
       let exitCode = 0;
       if (failOnError) {
@@ -40470,27 +40480,27 @@ var run = async () => {
     }
     const issueKey = issueKeys[issueKeys.length - 1];
     console.log(`JIRA key -> ${issueKey}`);
-    let key = "";
+    let ticketData;
     try {
-      key = (await jira.getIssue(issueKey)).key;
+      ticketData = await jira.getIssue(issueKey);
     } catch (error) {
       console.error(`Error while retrieving issue with key ${issueKey} from JIRA: `, error);
       console.log("Skipping.");
       return;
     }
+    const {
+      key,
+      fields: { summary }
+    } = ticketData;
+    const linkText = includeTitle ? `${key}: ${summary}` : key;
+    const linkBody = commentHeader + `${linkPrefix}[${linkText}](${jiraBaseURL}/browse/${key})` + commentTrailer;
     if (key) {
       if (updateBody) {
         console.log("Successfully retrieved issue from JIRA. Adding link to body of issue.");
-        await gh.updateBody({
-          ...commonPayload,
-          body: commentHeader + `JIRA Issue: [${key}](${jiraBaseURL}/browse/${key})` + commentTrailer
-        });
+        await gh.updateBody({ ...commonPayload, linkBody });
       } else {
         console.log("Successfully retrieved issue from JIRA. Adding link comment for issue.");
-        await gh.addComment({
-          ...commonPayload,
-          body: commentHeader + `JIRA Issue: [${key}](${jiraBaseURL}/browse/${key})` + commentTrailer
-        });
+        await gh.addComment({ ...commonPayload, body: linkBody });
       }
     } else {
       if (!issueKeys.length) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -37094,6 +37094,27 @@ var GitHub = class {
         core.setFailed(error?.message ?? "Failed to add comment");
       }
     };
+    this.updateBody = async (comment) => {
+      try {
+        const { owner, repo, issue: issue_number, body } = comment;
+        const issue = await this.client.issues.get({ owner, repo, issue_number });
+        if (!issue.data.body) {
+          await this.client.issues.update({ owner, repo, issue_number, body });
+        } else if (!issue.data.body.includes(body)) {
+          await this.client.issues.update({
+            owner,
+            repo,
+            issue_number,
+            body: `${body}
+
+${issue.data.body}`
+          });
+        }
+      } catch (error) {
+        console.error(error);
+        core.setFailed(error?.message ?? "Failed to update title");
+      }
+    };
     this.client = new Octokit2({ auth: token });
     if (this.client === void 0 || this.client === null) {
       throw new Error("Unable to create GitHub client");
@@ -40394,6 +40415,7 @@ var run = async () => {
     });
     const failOnError = core2.getInput("fail-on-error", { required: false }) !== "false";
     const forceUpdate = core2.getInput("force-update", { required: false }) === "true";
+    const updateBody = core2.getInput("update-body", { required: false }) === "true";
     const exit = (message) => {
       let exitCode = 0;
       if (failOnError) {
@@ -40431,10 +40453,12 @@ var run = async () => {
     const gh = new GitHub(githubToken);
     const jira = new Jira(jiraBaseURL, jiraUser, jiraToken);
     if (!headBranch && !baseBranch) {
-      await gh.addComment({
-        ...commonPayload,
-        body: "action-jira-linker is unable to determine the head and base branch."
-      });
+      if (!updateBody) {
+        await gh.addComment({
+          ...commonPayload,
+          body: "action-jira-linker is unable to determine the head and base branch."
+        });
+      }
       return exit("Unable to get the head and base branch.");
     }
     console.log("Base branch -> ", baseBranch);
@@ -40455,11 +40479,19 @@ var run = async () => {
       return;
     }
     if (key) {
-      console.log("Successfully retrieved issue from JIRA. Adding link comment for issue.");
-      await gh.addComment({
-        ...commonPayload,
-        body: commentHeader + `JIRA Issue: [${key}](${jiraBaseURL}/browse/${key})` + commentTrailer
-      });
+      if (updateBody) {
+        console.log("Successfully retrieved issue from JIRA. Adding link to body of issue.");
+        await gh.updateBody({
+          ...commonPayload,
+          body: commentHeader + `JIRA Issue: [${key}](${jiraBaseURL}/browse/${key})` + commentTrailer
+        });
+      } else {
+        console.log("Successfully retrieved issue from JIRA. Adding link comment for issue.");
+        await gh.addComment({
+          ...commonPayload,
+          body: commentHeader + `JIRA Issue: [${key}](${jiraBaseURL}/browse/${key})` + commentTrailer
+        });
+      }
     } else {
       if (!issueKeys.length) {
         console.log(`Could not find JIRA issue for key ${issueKey}. Skipping.`);

--- a/src/github.ts
+++ b/src/github.ts
@@ -27,4 +27,24 @@ export class GitHub {
 			core.setFailed((error as Error)?.message ?? 'Failed to add comment');
 		}
 	};
+
+	updateBody = async (comment: CreateIssueCommentParams): Promise<void> => {
+		try {
+			const { owner, repo, issue: issue_number, body } = comment;
+			const issue = await this.client.issues.get({ owner, repo, issue_number });
+			if (!issue.data.body) {
+				await this.client.issues.update({ owner, repo, issue_number, body });
+			} else if (!issue.data.body.includes(body)) {
+				await this.client.issues.update({
+					owner,
+					repo,
+					issue_number,
+					body: `${body}\n\n${issue.data.body}`,
+				});
+			}
+		} catch (error) {
+			console.error(error);
+			core.setFailed((error as Error)?.message ?? 'Failed to update title');
+		}
+	};
 }

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,6 +1,9 @@
 import * as core from '@actions/core';
 import * as octokit from '@octokit/rest';
-import { CreateIssueCommentParams } from './types';
+import { CreateIssueCommentParams, UpdateBodyParams } from './types';
+
+const BODY_HEADER = '<!-- jira link -->\r\n';
+const BODY_FOOTER = '\r\n<!-- end jira link -->';
 
 export class GitHub {
 	client: octokit.Octokit;
@@ -28,18 +31,21 @@ export class GitHub {
 		}
 	};
 
-	updateBody = async (comment: CreateIssueCommentParams): Promise<void> => {
+	updateBody = async (comment: UpdateBodyParams): Promise<void> => {
 		try {
-			const { owner, repo, issue: issue_number, body } = comment;
+			const { owner, repo, issue: issue_number, linkBody } = comment;
 			const issue = await this.client.issues.get({ owner, repo, issue_number });
-			if (!issue.data.body) {
+			let issueBody = issue.data.body;
+			const body = `${BODY_HEADER}${linkBody}${BODY_FOOTER}`;
+			if (!issueBody) {
 				await this.client.issues.update({ owner, repo, issue_number, body });
-			} else if (!issue.data.body.includes(body)) {
+			} else {
+				issueBody = issueBody.replace(new RegExp(`${BODY_HEADER}.*${BODY_FOOTER}`, 's'), '');
 				await this.client.issues.update({
 					owner,
 					repo,
 					issue_number,
-					body: `${body}\n\n${issue.data.body}`,
+					body: `${body}\n\n${issueBody}`,
 				});
 			}
 		} catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ const run = async () => {
 			required: false,
 		});
 		const failOnError: boolean = core.getInput('fail-on-error', { required: false }) !== 'false';
+		const forceUpdate: boolean = core.getInput('force-update', { required: false }) === 'true';
 
 		const exit = (message: string): void => {
 			let exitCode = 0;
@@ -47,7 +48,7 @@ const run = async () => {
 			return;
 		}
 
-		if (action !== 'opened') {
+		if (!forceUpdate && action !== 'opened') {
 			console.log('Skipping action to ensure we only comment once.');
 			return;
 		}

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,3 +83,10 @@ export interface CreateIssueCommentParams {
 	issue: number;
 	body: string;
 }
+
+export interface UpdateBodyParams {
+	owner: string;
+	repo: string;
+	issue: number;
+	linkBody: string;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,3 +76,10 @@ export interface JiraIssue {
 		[k: string]: unknown;
 	};
 }
+
+export interface CreateIssueCommentParams {
+	owner: string;
+	repo: string;
+	issue: number;
+	body: string;
+}


### PR DESCRIPTION
The `update-body` option can be used to prepend the jira link to the issue body instead of creating a comment. This is more useful for me, and possibly many others.

The `force-update` option can be useful in two ways:
 - When testing the action to ensure that the environment secrets and configuration are as needed, otherwise if the first attempt doesn't work there's no way to run a subsequent test.
 - When using `update-body`, the `updateBody` method already avoids making the comment if it's already there, so it can be useful to restore deleted comments or updating the description if the issue link changes etc.

I also added a missing type and added the `permissions` field to the documentation, since this seems to be necessary to have this action work since recent github updates.

Then two more options:

- ` include-title` for including the jira title in the link
- `link-prefix` (which defaults to `JIRA Issue: `) to customise that part of the comment